### PR TITLE
feat: add ERC1155Holder import for ERC1155Pool and ERC1155Vault

### DIFF
--- a/contracts/ERC-1155/ERC1155Pool.sol
+++ b/contracts/ERC-1155/ERC1155Pool.sol
@@ -2,13 +2,14 @@
 pragma solidity >=0.8.4;
 
 import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
 import "./IERC1155Pool.sol";
 
 import "./ERC20Wnft.sol";
 
 /// @title ERC1155Pool
 /// @author Hifi
-contract ERC1155Pool is IERC1155Pool, ERC20Wnft {
+contract ERC1155Pool is IERC1155Pool, ERC20Wnft, ERC1155Holder {
     /// PUBLIC STORAGE ///
 
     /// @dev The asset token IDs held in the pool.

--- a/contracts/ERC-1155/ERC1155Vault.sol
+++ b/contracts/ERC-1155/ERC1155Vault.sol
@@ -2,13 +2,14 @@
 pragma solidity >=0.8.4;
 
 import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
 import "./IERC1155Vault.sol";
 
 import "./ERC20Wnft.sol";
 
 /// @title ERC1155Vault
 /// @author Hifi
-contract ERC1155Vault is IERC1155Vault, ERC20Wnft {
+contract ERC1155Vault is IERC1155Vault, ERC20Wnft, ERC1155Holder {
     /// PUBLIC STORAGE ///
 
     /// @dev The asset tokens held for a user account in the vault.


### PR DESCRIPTION
For our implementation of the ERC1155Pool and ERC1155Vault contracts that need to receive ERC1155 tokens, we have a couple of options:

If we only need to receive ERC1155 tokens and don't require any additional functionality, we can inherit from ERC1155Holder to simplify our code.
If we want to implement additional functionality beyond simply receiving ERC1155 tokens, we can choose to implement onERC1155Received ourselves.
Based on our current requirements, we can use the former option to receive ERC1155 tokens.